### PR TITLE
Fix Stripe Link payment method not being sent to transactionInitialize

### DIFF
--- a/src/modules/stripe/components/stripe-checkout-form.tsx
+++ b/src/modules/stripe/components/stripe-checkout-form.tsx
@@ -5,6 +5,7 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js";
+import type { StripePaymentElementChangeEvent } from "@stripe/stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { useState } from "react";
 
@@ -52,9 +53,18 @@ export const StripeCheckoutFormWrapped = (props: {
   const stripe = useStripe();
   const elements = useElements();
   const [loading, setLoading] = useState(false);
+  const [paymentMethodType, setPaymentMethodType] = useState<string | null>(
+    null,
+  );
 
   const { mutateAsync: transactionInitialize } =
     useTransactionInitializeMutation();
+
+  const handlePaymentElementChange = (
+    event: StripePaymentElementChangeEvent,
+  ) => {
+    setPaymentMethodType(event.value.type);
+  };
 
   const handleSubmit = async (event: any) => {
     if (!stripe) {
@@ -81,7 +91,11 @@ export const StripeCheckoutFormWrapped = (props: {
 
     setLoading(true);
 
-    if (!selectedPaymentMethod) {
+    // Use selectedPaymentMethod from submit, or fall back to tracked type from onChange
+    // This handles Stripe Link which doesn't return selectedPaymentMethod from submit()
+    const resolvedPaymentMethod = selectedPaymentMethod || paymentMethodType;
+
+    if (!resolvedPaymentMethod) {
       setLoading(false);
       toast({
         variant: "destructive",
@@ -94,7 +108,7 @@ export const StripeCheckoutFormWrapped = (props: {
     const transactionInitializeResult = await transactionInitialize({
       data: {
         paymentIntent: {
-          paymentMethod: selectedPaymentMethod,
+          paymentMethod: resolvedPaymentMethod,
         },
       },
       saleorAmount: props.saleorAmount,
@@ -163,7 +177,7 @@ export const StripeCheckoutFormWrapped = (props: {
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <PaymentElement />
+      <PaymentElement onChange={handlePaymentElementChange} />
       <div className="flex justify-stretch">
         <FormButton
           type="submit"


### PR DESCRIPTION
## Summary

- Fix payment with Stripe Link failing because `elements.submit()` returns `selectedPaymentMethod` as undefined for Link
- Track the selected payment method type via `PaymentElement`'s `onChange` event and use it as a fallback

## Problem

When a user pays with Stripe Link (saved payment credentials), `elements.submit()` returns `selectedPaymentMethod` as **undefined** instead of `"link"`. This causes the `transactionInitialize` mutation to fail because no payment method type is provided.

## Solution

Use the `PaymentElement`'s `onChange` event to track the selected payment method type (`event.value.type`). When `elements.submit()` doesn't return `selectedPaymentMethod`, fall back to the value captured from `onChange`.

### Changes (`stripe-checkout-form.tsx`)

1. Import `StripePaymentElementChangeEvent` type
2. Add `paymentMethodType` state to track the selected type from `onChange`
3. Add `onChange` handler on `PaymentElement`
4. Resolve payment method as `selectedPaymentMethod || paymentMethodType`

## Test plan

- [ ] Pay with a new card — should work as before
- [ ] Register with Stripe Link during checkout
- [ ] On a subsequent payment, use saved Link credentials
- [ ] Verify `paymentMethod` sent to `transactionInitialize` is `"link"`
- [ ] Confirm payment completes successfully

## Related

https://github.com/saleor/apps/pull/2207

🤖 Generated with [Claude Code](https://claude.com/claude-code)