### PR TITLE
Allow next-image to consume sources from localhost saleor

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,11 @@ const nextConfig = {
         hostname: "*.saleor.cloud",
         port: "",
       },
+      {
+        protocol: "http",
+        hostname: "localhost",
+        port: "8000",
+      },
     ],
   },
 };


### PR DESCRIPTION
When test client used with Saleor on localhost, it failed to render product images due to strict image origin policy

Now localhost is allowed