### PR TITLE
build: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+FROM docker.io/node:24-slim AS base
+
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+FROM base AS deps
+
+# Ordered from least likely to most likely to change.
+COPY ./.npmrc ./
+COPY ./pnpm-workspace.yaml ./
+COPY ./package.json ./
+COPY ./pnpm-lock.yaml ./
+RUN HUSKY=0 pnpm install --frozen-lockfile
+
+FROM base AS builder
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY ./.npmrc ./package.json ./pnpm-lock.yaml ./pnpm-workspace.yaml ./
+
+# Ordered from least likely to most likely to change.
+COPY \
+  ./next.config.mjs \
+  ./postcss.config.mjs \
+  ./schema.graphql \
+  ./tailwind.config.ts \
+  ./tsconfig.json \
+  ./
+COPY ./src ./src
+
+# NEXT_PUBLIC_LOG_LEVEL={info, warn, error}
+ARG NEXT_PUBLIC_LOG_LEVEL=info
+ENV NEXT_PUBLIC_LOG_LEVEL=${NEXT_PUBLIC_LOG_LEVEL}
+
+ARG NEXT_PUBLIC_INITIAL_CHANNEL_SLUG=default-channel
+ENV NEXT_PUBLIC_INITIAL_CHANNEL_SLUG=${NEXT_PUBLIC_INITIAL_CHANNEL_SLUG}
+
+# Run the build
+RUN NEXT_OUTPUT=standalone pnpm build
+
+FROM docker.io/node:24-slim AS runner
+
+ENV NODE_ENV=production
+
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs \
+  && mkdir .next \
+  && chown nextjs:nodejs .next
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3331
+ENV PORT=3331
+CMD ["node", "server.js"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+name ?= payments-test-client
+
+build-container:
+	docker build -t $(name) .
+
+run-container:
+	@echo Hosting to http://localhost:3331
+	@docker run --rm --pull=never --name $(name) --publish=127.0.0.1:3331:3331 $(name)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output:
+    process.env.NEXT_OUTPUT === "standalone"
+      ? "standalone"
+      : process.env.NEXT_OUTPUT === "export"
+        ? "export"
+        : undefined,
   images: {
     remotePatterns: [
       {

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,7 +9,7 @@ export const env = createEnv({
     PORT: z.coerce.number().optional().default(3001),
   },
   client: {
-    NEXT_PUBLIC_INITIAL_ENV_URL: envUrlSchema,
+    NEXT_PUBLIC_INITIAL_ENV_URL: envUrlSchema.optional(),
     NEXT_PUBLIC_INITIAL_CHANNEL_SLUG: z.string(),
     NEXT_PUBLIC_INITIAL_CHECKOUT_COUNTRY_CODE: z
       .enum(["PL", "SE", "US"])


### PR DESCRIPTION
This adds a Dockerfile that builds a standalone Next.js build. This allows to more quickly be able to experiment with Adyen locally; this is only intended for using the project as is (not to develop, i.e., it does not replace `pnpm dev` command).